### PR TITLE
1. Moving away from the RH | 2. Adding buildx

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20 AS go_builder
+FROM --platform=$BUILDPLATFORM golang:1.20 AS go_builder
 WORKDIR /go/src/github.com/percona/percona-server-mongodb-operator
 
 COPY . .
@@ -6,18 +6,18 @@ COPY . .
 ARG GIT_COMMIT
 ARG GIT_BRANCH
 ARG GO_LDFLAGS
-ARG GOOS=linux
-ARG GOARCH=amd64
+ARG TARGETOS
+ARG TARGETARCH
 ARG CGO_ENABLED=0
 
 RUN go mod download \
     && mkdir -p build/_output/bin \
-    && GOOS=$GOOS GOARCH=$GOARCH CGO_ENABLED=$CGO_ENABLED GO_LDFLAGS=$GO_LDFLAGS \
+    && GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=$CGO_ENABLED GO_LDFLAGS=$GO_LDFLAGS \
        go build -ldflags "-w -s -X main.GitCommit=$GIT_COMMIT -X main.GitBranch=$GIT_BRANCH" \
            -o build/_output/bin/percona-server-mongodb-operator \
                cmd/manager/main.go \
     && cp -r build/_output/bin/percona-server-mongodb-operator /usr/local/bin/percona-server-mongodb-operator \
-    && GOOS=$GOOS GOARCH=$GOARCH CGO_ENABLED=$CGO_ENABLED GO_LDFLAGS=$GO_LDFLAGS \
+    && GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=$CGO_ENABLED GO_LDFLAGS=$GO_LDFLAGS \
        go build -ldflags "-w -s -X main.GitCommit=$GIT_COMMIT -X main.GitBranch=$GIT_BRANCH" \
            -o build/_output/bin/mongodb-healthcheck \
                cmd/mongodb-healthcheck/main.go \
@@ -30,8 +30,7 @@ RUN find $GOPATH/pkg/mod -regextype posix-extended -iregex '.*(license|notice)(\
             sh -c 'mkdir -pv /licenses/$(echo "$0" | sed -E "s/\/(license|notice).*$//gi") \
                    && cp -v "$0" /licenses/$(echo "$0" | sed -E "s/\/(license|notice).*$//gi")' {} \;
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal AS ubi9
-RUN microdnf update -y && microdnf clean all
+FROM gcr.io/distroless/cc-debian12 as production
 
 LABEL name="Percona Server for MongoDB Operator" \
       vendor="Percona" \
@@ -50,4 +49,4 @@ COPY build/ps-entry.sh /ps-entry.sh
 COPY build/physical-restore-ps-entry.sh /physical-restore-ps-entry.sh
 COPY build/pbm-entry.sh /pbm-entry.sh
 
-USER 2
+USER 65534:65534

--- a/e2e-tests/build
+++ b/e2e-tests/build
@@ -15,27 +15,31 @@ if [[ ${DOCKER_SQUASH:-1} == 1 ]]; then
 	squash="--squash"
 fi
 
+if [[ ${DOCKER_LOCAL:-1} == 1 ]]; then
+	output="--output=type=image"
+else
+	output="--output=type=registry"
+fi
+
 build_operator() {
 	if [ "${RELEASE:-1}" = 0 ]; then
 		GO_LDFLAGS="-race"
 	fi
 
 	export IMAGE
-	export DOCKER_DEFAULT_PLATFORM=${DOCKER_DEFAULT_PLATFORM:-linux/amd64}
 	export GO_LDFLAGS="-w -s -trimpath $GO_LDFLAGS"
 	pushd ${src_dir}
-	docker build \
+	docker buildx build \
+		--platform linux/arm64,linux/amd64 \
 		--build-arg GIT_COMMIT=$GIT_COMMIT \
 		--build-arg GIT_BRANCH=$GIT_BRANCH \
 		--build-arg GO_LDFLAGS="$GO_LDFLAGS" \
+		$output \
 		$squash \
 		$no_cache \
 		-t "${IMAGE}" -f build/Dockerfile .
 	popd
 
-	if [ "${DOCKER_PUSH:-1}" = 1 ]; then
-		docker push ${IMAGE}
-	fi
 }
 
 until docker ps; do sleep 1; done


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
*Internal usahe changes*

**Cause:**
*For building multiarch images for internal consumption*

**Solution:**
*Modify the build script to use `buildx`*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
